### PR TITLE
Include timestamps in broadcasted events

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -68,9 +68,10 @@ function sendMessage() {
   msgInput.value = '';
 }
 
-socket.on('chatMessage', ({ sender, message }) => {
+socket.on('chatMessage', ({ sender, message, timestamp }) => {
   const li = document.createElement('li');
-  li.textContent = `${sender}: ${message}`;
+  const time = new Date(timestamp).toLocaleTimeString();
+  li.textContent = `[${time}] ${sender}: ${message}`;
   messages.appendChild(li);
 });
 
@@ -87,13 +88,13 @@ video.addEventListener('timeupdate', () => {
   }
 });
 
-socket.on('videoTimeUpdate', (time) => {
+socket.on('videoTimeUpdate', ({ time }) => {
   if (Math.abs(video.currentTime - time) > 0.5) {
     video.currentTime = time;
   }
 });
 
-socket.on('videoStateChange', (playing) => {
+socket.on('videoStateChange', ({ playing }) => {
   if (playing && video.paused) video.play();
   if (!playing && !video.paused) video.pause();
 });

--- a/server.js
+++ b/server.js
@@ -48,7 +48,7 @@ io.on('connection', (socket) => {
       socket.join(key);
       socket.name = name;
       socket.room = key;
-      socket.emit('videoState', room.video);
+      socket.emit('videoState', { ...room.video, timestamp: new Date().toISOString() });
       cb && cb({ ok: true });
     } else {
       cb && cb({ ok: false, error: 'Room not found' });
@@ -56,20 +56,23 @@ io.on('connection', (socket) => {
   });
 
   socket.on('chatMessage', ({ room, message }) => {
-    io.to(room).emit('chatMessage', { sender: socket.name, message });
+    const timestamp = new Date().toISOString();
+    io.to(room).emit('chatMessage', { sender: socket.name, message, timestamp });
   });
 
   socket.on('videoTimeUpdate', ({ room, time }) => {
     if (rooms[room]) {
       rooms[room].video.time = time;
-      socket.to(room).emit('videoTimeUpdate', time);
+      const timestamp = new Date().toISOString();
+      socket.to(room).emit('videoTimeUpdate', { time, timestamp });
     }
   });
 
   socket.on('videoStateChange', ({ room, playing }) => {
     if (rooms[room]) {
       rooms[room].video.playing = playing;
-      socket.to(room).emit('videoStateChange', playing);
+      const timestamp = new Date().toISOString();
+      socket.to(room).emit('videoStateChange', { playing, timestamp });
     }
   });
 


### PR DESCRIPTION
## Summary
- attach ISO timestamps to video state, chat, time update, and play/pause events on the server
- display timestamped chat messages and accept timestamped video events in the client

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c00f3ba47483338a6db56d69a8bd44